### PR TITLE
Create garage sale discovery web app

### DIFF
--- a/components/SaleDetailDrawer.tsx
+++ b/components/SaleDetailDrawer.tsx
@@ -1,0 +1,48 @@
+import { SaleListing } from '../lib/types';
+
+interface SaleDetailDrawerProps {
+  sale: SaleListing | null;
+  onClose: () => void;
+}
+
+export function SaleDetailDrawer({ sale, onClose }: SaleDetailDrawerProps) {
+  return (
+    <aside className={`detail-drawer ${sale ? 'open' : ''}`}>
+      <button className="close-button" onClick={onClose} aria-label="Close details">
+        ×
+      </button>
+      {sale ? (
+        <div className="detail-content">
+          <h2>{sale.title}</h2>
+          <p className="address">{sale.address}</p>
+          <p className="dates">
+            {new Date(sale.startDate).toLocaleDateString()} –{' '}
+            {new Date(sale.endDate).toLocaleDateString()}
+            {sale.startTime && sale.endTime
+              ? ` • ${sale.startTime} to ${sale.endTime}`
+              : ''}
+          </p>
+          <p className="description">{sale.description}</p>
+          {sale.tags && sale.tags.length > 0 ? (
+            <div className="tag-list">
+              {sale.tags.map((tag) => (
+                <span key={tag} className="tag-pill">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          ) : null}
+          {sale.sourceUrl ? (
+            <a href={sale.sourceUrl} target="_blank" rel="noreferrer" className="source-link">
+              View original listing ↗
+            </a>
+          ) : null}
+        </div>
+      ) : (
+        <div className="detail-placeholder">
+          <p>Select a sale to see the details.</p>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/components/SaleList.tsx
+++ b/components/SaleList.tsx
@@ -1,0 +1,46 @@
+import { SaleListing } from '../lib/types';
+
+interface SaleListProps {
+  sales: SaleListing[];
+  onSelect: (sale: SaleListing) => void;
+}
+
+export function SaleList({ sales, onSelect }: SaleListProps) {
+  if (sales.length === 0) {
+    return (
+      <div className="sale-list empty">
+        <p>No sales found just yet. Try expanding your search!</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="sale-list">
+      {sales.map((sale) => (
+        <button key={sale.id} className="sale-card" onClick={() => onSelect(sale)}>
+          <div className="sale-card-header">
+            <h3>{sale.title}</h3>
+            <span className={`tag ${sale.source}`}>{sale.source}</span>
+          </div>
+          <p className="address">{sale.address}</p>
+          <p className="dates">
+            {new Date(sale.startDate).toLocaleDateString()} –{' '}
+            {new Date(sale.endDate).toLocaleDateString()}
+            {sale.startTime && sale.endTime
+              ? ` • ${sale.startTime} to ${sale.endTime}`
+              : ''}
+          </p>
+          {sale.tags && sale.tags.length > 0 ? (
+            <div className="tag-list">
+              {sale.tags.map((tag) => (
+                <span key={tag} className="tag-pill">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/SaleMap.tsx
+++ b/components/SaleMap.tsx
@@ -1,0 +1,63 @@
+import { MapContainer, Marker, Popup, TileLayer, useMap } from 'react-leaflet';
+import { Icon, LatLngExpression } from 'leaflet';
+import { useEffect } from 'react';
+import { SaleListing } from '../lib/types';
+
+const markerIconData =
+  'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSczNicgaGVpZ2h0PSczNicgdmlld0JveD0nMCAwIDM2IDM2Jz48cGF0aCBmaWxsPScjZDk3NzU3JyBkPSdNMTggMGM2LjYgMCAxMiA1LjQgMTIgMTIgMCA3LjUtOS42IDE5LjItMTEuMyAyMS4xLS40LjUtMS4xLjUtMS41IDBDMTUuNiAzMS4yIDYgMTkuNSA2IDEyIDYgNS40IDExLjQgMCAxOCAweicvPjxjaXJjbGUgZmlsbD0nd2hpdGUnIGN4PScxOCcgY3k9JzEyJyByPSc1Jy8+PC9zdmc+';
+
+const homeyIcon = new Icon({
+  iconUrl: markerIconData,
+  iconSize: [36, 36],
+  iconAnchor: [18, 36],
+  popupAnchor: [0, -28]
+});
+
+function MapViewUpdater({ center }: { center: LatLngExpression }) {
+  const map = useMap();
+
+  useEffect(() => {
+    map.flyTo(center, map.getZoom(), { duration: 0.75 });
+  }, [center, map]);
+
+  return null;
+}
+
+interface SaleMapProps {
+  sales: SaleListing[];
+  center: LatLngExpression;
+  onSelect: (sale: SaleListing) => void;
+}
+
+export function SaleMap({ sales, center, onSelect }: SaleMapProps) {
+  return (
+    <div className="map-wrapper">
+      <MapContainer center={center} zoom={11} scrollWheelZoom className="map">
+        <MapViewUpdater center={center} />
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        {sales.map((sale) => (
+          <Marker
+            position={[sale.latitude, sale.longitude] as LatLngExpression}
+            key={sale.id}
+            icon={homeyIcon}
+            eventHandlers={{
+              click: () => onSelect(sale)
+            }}
+          >
+            <Popup>
+              <strong>{sale.title}</strong>
+              <br />
+              {sale.address}
+              <br />
+              {new Date(sale.startDate).toLocaleDateString()} –{' '}
+              {new Date(sale.endDate).toLocaleDateString()}
+            </Popup>
+          </Marker>
+        ))}
+      </MapContainer>
+    </div>
+  );
+}

--- a/components/SearchControls.tsx
+++ b/components/SearchControls.tsx
@@ -1,0 +1,65 @@
+import { FormEvent, useState } from 'react';
+
+interface SearchControlsProps {
+  onGeolocate: () => void;
+  onSearchZip: (zip: string) => void;
+  isLocating: boolean;
+}
+
+export function SearchControls({
+  onGeolocate,
+  onSearchZip,
+  isLocating
+}: SearchControlsProps) {
+  const [zip, setZip] = useState('');
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (zip.trim()) {
+      onSearchZip(zip.trim());
+    }
+  };
+
+  return (
+    <div className="search-controls">
+      <div className="search-card">
+        <h1>Find a Cozy Sale Nearby</h1>
+        <p>
+          Discover community garage, tag, and estate sales in a safe and
+          welcoming experience. Start by sharing your location or enter a zip
+          code to explore.
+        </p>
+        <div className="search-actions">
+          <button
+            type="button"
+            className="primary"
+            onClick={onGeolocate}
+            disabled={isLocating}
+          >
+            {isLocating ? 'Locating…' : 'Find Near Me'}
+          </button>
+          <span className="separator">or</span>
+          <form onSubmit={handleSubmit} className="zip-form">
+            <label htmlFor="zip-input" className="sr-only">
+              Enter Zip Code
+            </label>
+            <input
+              id="zip-input"
+              type="text"
+              placeholder="Zip Code"
+              value={zip}
+              onChange={(event) => setZip(event.target.value)}
+              pattern="\\d{5}"
+              maxLength={5}
+              inputMode="numeric"
+              required
+            />
+            <button type="submit" className="secondary">
+              Search
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/sales/scraper.ts
+++ b/lib/sales/scraper.ts
@@ -1,0 +1,129 @@
+import axios from 'axios';
+import * as cheerio from 'cheerio';
+import { SaleListing } from '../types';
+import { fallbackSales } from './staticData';
+
+const ESTATE_SALES_NET = 'https://www.estatesales.net/estate-sales';
+const GARAGE_SALE_FINDER = 'https://gsalr.com/';
+
+function parseDate(dateText: string): string | undefined {
+  const normalized = dateText.trim().replace(/\s+/g, ' ');
+  const parsed = Date.parse(normalized);
+  if (!Number.isNaN(parsed)) {
+    return new Date(parsed).toISOString();
+  }
+  return undefined;
+}
+
+async function scrapeEstateSalesNet(): Promise<SaleListing[]> {
+  try {
+    const { data } = await axios.get(ESTATE_SALES_NET, {
+      headers: {
+        'User-Agent':
+          'GarageSaleHunterBot/0.1 (+https://garage-sale-hunter.example)'
+      },
+      timeout: 5000
+    });
+
+    const $ = cheerio.load(data);
+    const listings: SaleListing[] = [];
+
+    $('.sale-card').each((_, element) => {
+      const title = $(element).find('.sale-title').text().trim();
+      const address = $(element).find('.sale-address').text().trim();
+      const dateRange = $(element).find('.sale-dates').text().trim();
+      const url = $(element).find('a.sale-title').attr('href');
+
+      if (!title || !address || !dateRange) return;
+
+      const [startRaw, endRaw] = dateRange.split('to').map((part) => part.trim());
+
+      listings.push({
+        id: `estatesales-${Buffer.from(title + address).toString('base64')}`,
+        title,
+        description: `${title} — discovered on EstateSales.net`,
+        address,
+        city: '',
+        state: '',
+        postalCode: '',
+        latitude: 0,
+        longitude: 0,
+        startDate: parseDate(startRaw) ?? new Date().toISOString(),
+        endDate: parseDate(endRaw ?? startRaw) ?? new Date().toISOString(),
+        source: 'scraped',
+        sourceUrl: url ? new URL(url, ESTATE_SALES_NET).toString() : ESTATE_SALES_NET,
+        tags: ['estate sale'],
+        createdAt: new Date().toISOString()
+      });
+    });
+
+    return listings;
+  } catch (error) {
+    console.warn('Failed to scrape EstateSales.net', error);
+    return [];
+  }
+}
+
+async function scrapeGarageSaleFinder(): Promise<SaleListing[]> {
+  try {
+    const { data } = await axios.get(GARAGE_SALE_FINDER, {
+      headers: {
+        'User-Agent':
+          'GarageSaleHunterBot/0.1 (+https://garage-sale-hunter.example)'
+      },
+      timeout: 5000
+    });
+
+    const $ = cheerio.load(data);
+    const listings: SaleListing[] = [];
+
+    $('.event-list .event').each((_, element) => {
+      const title = $(element).find('.event-title').text().trim();
+      const address = $(element).find('.event-location').text().trim();
+      const dateText = $(element).find('.event-date').text().trim();
+      const url = $(element).find('a').attr('href');
+
+      if (!title || !address || !dateText) return;
+
+      listings.push({
+        id: `gsalr-${Buffer.from(title + address).toString('base64')}`,
+        title,
+        description: `${title} — collected from Gsalr.com`,
+        address,
+        city: '',
+        state: '',
+        postalCode: '',
+        latitude: 0,
+        longitude: 0,
+        startDate: parseDate(dateText) ?? new Date().toISOString(),
+        endDate: parseDate(dateText) ?? new Date().toISOString(),
+        source: 'scraped',
+        sourceUrl: url ? new URL(url, GARAGE_SALE_FINDER).toString() : GARAGE_SALE_FINDER,
+        tags: ['garage sale'],
+        createdAt: new Date().toISOString()
+      });
+    });
+
+    return listings;
+  } catch (error) {
+    console.warn('Failed to scrape Gsalr.com', error);
+    return [];
+  }
+}
+
+export async function scrapeAllSales(): Promise<SaleListing[]> {
+  const [estateSales, garageSales] = await Promise.all([
+    scrapeEstateSalesNet(),
+    scrapeGarageSaleFinder()
+  ]);
+
+  const scraped = [...estateSales, ...garageSales];
+
+  if (scraped.length === 0) {
+    return fallbackSales;
+  }
+
+  return scraped.concat(
+    fallbackSales.filter((sale) => sale.source === 'community')
+  );
+}

--- a/lib/sales/staticData.ts
+++ b/lib/sales/staticData.ts
@@ -1,0 +1,43 @@
+import { SaleListing } from '../types';
+
+export const fallbackSales: SaleListing[] = [
+  {
+    id: 'fallback-1',
+    title: 'Sunny Saturday Garage Sale',
+    description:
+      'Family-friendly sale with vintage kitchenware, kids clothes, and a cozy lemonade stand. Perfect for a relaxed Saturday stroll.',
+    address: '123 Maple Lane',
+    city: 'Springfield',
+    state: 'IL',
+    postalCode: '62704',
+    latitude: 39.7817,
+    longitude: -89.6501,
+    startDate: new Date().toISOString(),
+    endDate: new Date(Date.now() + 24 * 3600 * 1000).toISOString(),
+    startTime: '08:00',
+    endTime: '15:00',
+    source: 'community',
+    tags: ['multi-family', 'vintage', 'kid-friendly'],
+    createdAt: new Date().toISOString()
+  },
+  {
+    id: 'fallback-2',
+    title: 'Estate Sale with Antique Finds',
+    description:
+      'Estate sale featuring restored furniture, collectible dish sets, and hand-crafted quilts. Sourced from EstateSales.net.',
+    address: '45 Willow Creek Drive',
+    city: 'Madison',
+    state: 'WI',
+    postalCode: '53711',
+    latitude: 43.0731,
+    longitude: -89.4012,
+    startDate: new Date(Date.now() + 2 * 24 * 3600 * 1000).toISOString(),
+    endDate: new Date(Date.now() + 3 * 24 * 3600 * 1000).toISOString(),
+    startTime: '09:00',
+    endTime: '17:00',
+    source: 'scraped',
+    sourceUrl: 'https://www.estatesales.net/',
+    tags: ['antiques', 'furniture'],
+    createdAt: new Date().toISOString()
+  }
+];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,26 @@
+export type SaleSource = 'community' | 'scraped';
+
+export interface SaleListing {
+  id: string;
+  title: string;
+  description: string;
+  address: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  latitude: number;
+  longitude: number;
+  startDate: string;
+  endDate: string;
+  startTime?: string;
+  endTime?: string;
+  source: SaleSource;
+  sourceUrl?: string;
+  tags: string[];
+  createdAt: string;
+}
+
+export interface SalesResponse {
+  sales: SaleListing[];
+  generatedAt: string;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "garage-sale-hunter",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "cheerio": "^1.0.0-rc.12",
+    "leaflet": "^1.9.4",
+    "next": "^14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-leaflet": "^4.2.1",
+    "swr": "^2.2.4"
+  },
+  "devDependencies": {
+    "eslint": "^8.56.0",
+    "eslint-config-next": "^14.1.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,20 @@
+import type { AppProps } from 'next/app';
+import Head from 'next/head';
+import 'leaflet/dist/leaflet.css';
+import '../styles/globals.css';
+
+export default function GarageSaleHunterApp({ Component, pageProps }: AppProps) {
+  return (
+    <>
+      <Head>
+        <title>Garage Sale Hunter</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="description"
+          content="Discover nearby garage, tag, and estate sales with a homey and trusted experience."
+        />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
+}

--- a/pages/api/geocode.ts
+++ b/pages/api/geocode.ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import axios from 'axios';
+
+interface GeocodeResult {
+  latitude: number;
+  longitude: number;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<GeocodeResult | { error: string }>
+) {
+  const query = (req.query.q as string | undefined)?.trim();
+
+  if (!query) {
+    res.status(400).json({ error: 'Missing query parameter "q"' });
+    return;
+  }
+
+  try {
+    const { data } = await axios.get(
+      'https://nominatim.openstreetmap.org/search',
+      {
+        params: {
+          format: 'json',
+          limit: 1,
+          q: query
+        },
+        headers: {
+          'User-Agent': 'GarageSaleHunter/0.1 (https://garage-sale-hunter.example)'
+        },
+        timeout: 5000
+      }
+    );
+
+    if (Array.isArray(data) && data.length > 0) {
+      const result = data[0];
+      res.status(200).json({
+        latitude: parseFloat(result.lat),
+        longitude: parseFloat(result.lon)
+      });
+      return;
+    }
+
+    res.status(404).json({ error: 'No results found' });
+  } catch (error) {
+    console.error('Geocoding failed', error);
+    res.status(500).json({ error: 'Geocoding failed' });
+  }
+}

--- a/pages/api/sales.ts
+++ b/pages/api/sales.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { scrapeAllSales } from '../../lib/sales/scraper';
+import type { SalesResponse } from '../../lib/types';
+
+const CACHE_DURATION_MS = 10 * 60 * 1000; // 10 minutes
+
+let cachedResponse: SalesResponse | null = null;
+let lastFetchedAt = 0;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<SalesResponse>
+) {
+  const now = Date.now();
+
+  if (!cachedResponse || now - lastFetchedAt > CACHE_DURATION_MS) {
+    const sales = await scrapeAllSales();
+    cachedResponse = {
+      sales,
+      generatedAt: new Date().toISOString()
+    };
+    lastFetchedAt = now;
+  }
+
+  res.setHeader('Cache-Control', 's-maxage=600, stale-while-revalidate');
+  res.status(200).json(cachedResponse);
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,134 @@
+import dynamic from 'next/dynamic';
+import { useCallback, useMemo, useState } from 'react';
+import useSWR from 'swr';
+import axios from 'axios';
+import { SearchControls } from '../components/SearchControls';
+import { SaleList } from '../components/SaleList';
+import { SaleDetailDrawer } from '../components/SaleDetailDrawer';
+import type { SaleListing, SalesResponse } from '../lib/types';
+
+const DynamicSaleMap = dynamic(
+  () => import('../components/SaleMap').then((mod) => mod.SaleMap),
+  { ssr: false }
+);
+
+type ViewMode = 'map' | 'list';
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export default function HomePage() {
+  const { data, error, isLoading } = useSWR<SalesResponse>('/api/sales', fetcher, {
+    refreshInterval: 5 * 60 * 1000
+  });
+  const [selectedSale, setSelectedSale] = useState<SaleListing | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>('map');
+  const [isLocating, setIsLocating] = useState(false);
+  const [mapCenter, setMapCenter] = useState<[number, number]>([39.8283, -98.5795]);
+
+  const salesWithCoordinates = useMemo(() => {
+    if (!data?.sales) return [];
+    return data.sales
+      .filter(
+        (sale) =>
+          Number.isFinite(sale.latitude) &&
+          Number.isFinite(sale.longitude) &&
+          (sale.latitude !== 0 || sale.longitude !== 0)
+      )
+      .sort(
+        (a, b) =>
+          new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
+      );
+  }, [data?.sales]);
+
+  const handleLocateMe = useCallback(() => {
+    if (!navigator.geolocation) {
+      alert('Geolocation is not supported on this device.');
+      return;
+    }
+    setIsLocating(true);
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const { latitude, longitude } = position.coords;
+        setMapCenter([latitude, longitude]);
+        setIsLocating(false);
+      },
+      () => {
+        alert('Unable to access your location.');
+        setIsLocating(false);
+      }
+    );
+  }, []);
+
+  const handleSearchZip = useCallback(async (zip: string) => {
+    try {
+      const response = await axios.get('/api/geocode', { params: { q: zip } });
+      const { latitude, longitude } = response.data;
+      setMapCenter([latitude, longitude]);
+    } catch (zipError) {
+      console.error('Zip lookup failed', zipError);
+      alert('Unable to find that zip code. Please try a different one.');
+    }
+  }, []);
+
+  const handleSelectSale = useCallback((sale: SaleListing) => {
+    setSelectedSale(sale);
+  }, []);
+
+  const handleCloseDrawer = useCallback(() => {
+    setSelectedSale(null);
+  }, []);
+
+  return (
+    <main>
+      <SearchControls
+        onGeolocate={handleLocateMe}
+        onSearchZip={handleSearchZip}
+        isLocating={isLocating}
+      />
+
+      <div className="view-toggle">
+        <button
+          className={viewMode === 'map' ? 'active' : ''}
+          onClick={() => setViewMode('map')}
+        >
+          Map View
+        </button>
+        <button
+          className={viewMode === 'list' ? 'active' : ''}
+          onClick={() => setViewMode('list')}
+        >
+          List View
+        </button>
+      </div>
+
+      {error ? (
+        <p style={{ padding: '0 1.5rem 2rem', color: '#b91c1c' }}>
+          We hit a snag fetching sales. Please refresh to try again.
+        </p>
+      ) : null}
+
+      {isLoading && !data ? (
+        <p style={{ padding: '0 1.5rem 2rem' }}>Gathering the warmest listings…</p>
+      ) : null}
+
+      <div className="content-wrapper">
+        {viewMode === 'map' ? (
+          <>
+            <DynamicSaleMap
+              sales={salesWithCoordinates}
+              center={mapCenter}
+              onSelect={handleSelectSale}
+            />
+            <SaleList sales={salesWithCoordinates} onSelect={handleSelectSale} />
+          </>
+        ) : null}
+
+        {viewMode === 'list' ? (
+          <SaleList sales={salesWithCoordinates} onSelect={handleSelectSale} />
+        ) : null}
+      </div>
+
+      <SaleDetailDrawer sale={selectedSale} onClose={handleCloseDrawer} />
+    </main>
+  );
+}

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,61 @@
-readme
+# Garage Sale Hunter
+
+Garage Sale Hunter is a Next.js web application that makes it easy to discover nearby garage, tag, and estate sales with a homey and trustworthy interface. Visitors can quickly share their location or search by zip code, explore an interactive map, switch to a list-focused view, and read detailed sale information pulled from community submissions and scraped listings.
+
+## Features
+
+- **Location-first onboarding** – The app immediately invites visitors to share their location or search by zip code.
+- **Interactive map** – Powered by OpenStreetMap and Leaflet with warm, friendly styling and callouts for each sale.
+- **List view toggle** – Users can swap between the map experience and a list-focused layout for easy scanning.
+- **Sale details drawer** – Tapping a pin or list item reveals rich sale information, including dates, hours, tags, and a link back to the original source when the listing was scraped.
+- **Background scraping** – Server-side scraping utilities collect fresh listings from popular public garage sale directories and blend them with curated fallback data so the interface always feels populated.
+- **Geocoding helper** – A minimal API route proxies requests to OpenStreetMap&apos;s Nominatim service to convert zip codes into map coordinates.
+
+## Getting Started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Run the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+   The application will be available at [http://localhost:3000](http://localhost:3000).
+
+3. Build for production:
+
+   ```bash
+   npm run build
+   npm start
+   ```
+
+## Scraping Notes
+
+- Scraping is handled in `lib/sales/scraper.ts` using Axios and Cheerio.
+- Listings are cached for 10 minutes by the `/api/sales` endpoint to avoid excessive outbound requests.
+- When live scraping is unsuccessful, the app falls back to the warm and friendly sample data located in `lib/sales/staticData.ts` so the interface remains welcoming.
+- Always respect the terms of service for third-party sites before deploying the scraper in production. Configure request headers, throttling, and source allowlists as needed.
+
+## Geocoding
+
+The `/api/geocode` endpoint proxies to Nominatim. In production usage, please:
+
+- Add your contact information to the `User-Agent` header.
+- Implement request throttling or caching as appropriate.
+- Consider supplying your own geocoding data store if traffic is expected to be high.
+
+## Technology
+
+- [Next.js](https://nextjs.org/) for the application framework and API routes.
+- [React Leaflet](https://react-leaflet.js.org/) and [Leaflet](https://leafletjs.com/) for mapping.
+- [SWR](https://swr.vercel.app/) for lightweight data fetching.
+- [Axios](https://axios-http.com/) and [Cheerio](https://cheerio.js.org/) for scraping.
+
+## License
+
+This project is provided as-is for demonstration purposes.

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,375 @@
+:root {
+  color-scheme: light;
+  --background: #fdf8f4;
+  --surface: #ffffff;
+  --primary: #d97757;
+  --primary-dark: #b55f3f;
+  --accent: #f2c94c;
+  --text: #2c2a29;
+  --muted: #766b62;
+  --border: #e7d9ce;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  background: var(--background);
+  color: var(--text);
+  min-height: 100%;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font-family: inherit;
+}
+
+main {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.search-controls {
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1.5rem 1rem;
+}
+
+.search-card {
+  background: var(--surface);
+  border-radius: 20px;
+  padding: 2.5rem;
+  max-width: 720px;
+  text-align: center;
+  box-shadow: 0 20px 40px rgba(217, 119, 87, 0.12);
+  border: 1px solid var(--border);
+}
+
+.search-card h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.search-card p {
+  margin: 0 auto 1.5rem;
+  color: var(--muted);
+  max-width: 540px;
+}
+
+.search-actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+button.primary,
+button.secondary {
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.6rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+  color: white;
+  box-shadow: 0 15px 30px rgba(217, 119, 87, 0.3);
+}
+
+button.primary:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button.primary:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 38px rgba(217, 119, 87, 0.35);
+}
+
+button.secondary {
+  background: white;
+  color: var(--primary);
+  border: 2px solid rgba(217, 119, 87, 0.4);
+}
+
+button.secondary:hover {
+  border-color: var(--primary);
+}
+
+.separator {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.zip-form {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.zip-form input {
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  min-width: 160px;
+  background: #fff9f5;
+}
+
+.zip-form input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(217, 119, 87, 0.2);
+}
+
+.content-wrapper {
+  display: flex;
+  flex: 1;
+  padding: 0 1.5rem 2rem;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.map-wrapper {
+  flex: 2;
+  min-width: 360px;
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(44, 42, 41, 0.1);
+  border: 1px solid var(--border);
+}
+
+.map {
+  height: 520px;
+  width: 100%;
+}
+
+.sale-list {
+  flex: 1;
+  min-width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-height: 520px;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.content-wrapper > .sale-list:only-child {
+  flex: 1 1 100%;
+  max-height: none;
+}
+
+.sale-list.empty {
+  align-items: center;
+  justify-content: center;
+}
+
+.sale-card {
+  text-align: left;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 1.25rem;
+  box-shadow: 0 12px 24px rgba(44, 42, 41, 0.08);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  cursor: pointer;
+}
+
+.sale-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 18px 32px rgba(44, 42, 41, 0.12);
+}
+
+.sale-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.sale-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.sale-card .tag {
+  padding: 0.15rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.tag.community {
+  background: rgba(242, 201, 76, 0.25);
+  color: #8a5b19;
+}
+
+.tag.scraped {
+  background: rgba(94, 201, 145, 0.22);
+  color: #2f6f4f;
+}
+
+.sale-card .address {
+  color: var(--muted);
+  margin: 0.35rem 0;
+}
+
+.sale-card .dates {
+  margin: 0.35rem 0 0.5rem;
+  color: #5c4b43;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.tag-pill {
+  background: rgba(44, 42, 41, 0.08);
+  color: #4f3b2f;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+.detail-drawer {
+  position: fixed;
+  right: 0;
+  top: 0;
+  height: 100vh;
+  width: min(420px, 90vw);
+  background: var(--surface);
+  box-shadow: -12px 0 30px rgba(44, 42, 41, 0.08);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  z-index: 1000;
+  padding: 1.5rem;
+}
+
+.detail-drawer.open {
+  transform: translateX(0);
+}
+
+.close-button {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.detail-content {
+  margin-top: 2rem;
+}
+
+.detail-content h2 {
+  margin: 0 0 0.75rem;
+}
+
+.detail-content .address {
+  color: var(--muted);
+}
+
+.detail-content .description {
+  margin-top: 1rem;
+  line-height: 1.5;
+}
+
+.source-link {
+  display: inline-flex;
+  margin-top: 1.25rem;
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.detail-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--muted);
+}
+
+.view-toggle {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  padding: 0 1.5rem 1rem;
+}
+
+.view-toggle button {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.45rem 1.2rem;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.view-toggle button.active {
+  border-color: var(--primary);
+  color: var(--primary);
+  background: rgba(217, 119, 87, 0.1);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 960px) {
+  .map {
+    height: 420px;
+  }
+
+  .sale-list {
+    max-height: none;
+    order: 2;
+  }
+}
+
+@media (max-width: 640px) {
+  .search-card {
+    padding: 1.75rem 1.5rem;
+  }
+
+  .map-wrapper,
+  .sale-list {
+    width: 100%;
+  }
+}
+
+.leaflet-container {
+  font-family: inherit;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": []
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js application with warm styling for browsing garage, tag, and estate sales
- add interactive Leaflet map, list view toggle, and detail drawer for sale exploration
- implement scraping and geocoding API routes with cached responses and friendly fallback data

## Testing
- npm install *(fails: registry access returns 403 Forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ce1892b8832189976e1b6a0c045b